### PR TITLE
Shallow clone the primary checkout and submodules

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,8 +22,8 @@ runs:
       working-directory: '${{github.workspace}}'
       if: ${{ github.event_name == 'pull_request' }}
       run: |
-        git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin '${{github.event.pull_request.head.sha}}'
-        git checkout --force '${{github.event.pull_request.head.sha}}'
+        git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin '${{github.sha}}'
+        git checkout --force '${{github.sha}}'
         git config user.name "Actions Runner"
         git config user.email "noreply@example.com"
     - name: Checkout for branches

--- a/action.yml
+++ b/action.yml
@@ -17,22 +17,14 @@ runs:
       working-directory: '${{github.workspace}}'
       run: |
         git remote add origin 'git@github.com:${{github.repository}}'
-    - name: Checkout for PRs
+    - name: Checkout branch or PR
       shell: bash
       working-directory: '${{github.workspace}}'
-      if: ${{ github.event_name == 'pull_request' }}
       run: |
         git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin '${{github.sha}}'
         git checkout --force '${{github.sha}}'
         git config user.name "Actions Runner"
         git config user.email "noreply@example.com"
-    - name: Checkout for branches
-      shell: bash
-      working-directory: '${{github.workspace}}'
-      if: ${{ github.event_name != 'pull_request' }}
-      run: |
-        git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin '${{github.sha}}'
-        git checkout --force '${{github.sha}}'
     - name: Update submodules
       shell: bash
       working-directory: '${{github.workspace}}'

--- a/action.yml
+++ b/action.yml
@@ -7,31 +7,38 @@ runs:
       shell: bash
       run: |
         rm -rf '${{github.workspace}}'
-    - name: Clone
+    - name: Init
       shell: bash
       working-directory: '${{runner.workspace}}'
       run: |
-        git clone 'git@github.com:${{github.repository}}'
+        git init '${{github.workspace}}'
+    - name: Add origin
+      shell: bash
+      working-directory: '${{github.workspace}}'
+      run: |
+        git remote add origin 'git@github.com:${{github.repository}}'
     - name: Checkout for PRs
       shell: bash
       working-directory: '${{github.workspace}}'
       if: ${{ github.event_name == 'pull_request' }}
       run: |
-        git checkout '${{github.event.pull_request.head.sha}}'
+        git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin '${{github.event.pull_request.head.sha}}'
+        git checkout --force '${{github.event.pull_request.head.sha}}'
         git config user.name "Actions Runner"
         git config user.email "noreply@example.com"
-        git merge --no-commit 'origin/${{github.base_ref}}'
     - name: Checkout for branches
       shell: bash
       working-directory: '${{github.workspace}}'
       if: ${{ github.event_name != 'pull_request' }}
       run: |
-        git checkout '${{github.sha}}'
+        git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin '${{github.sha}}'
+        git checkout --force '${{github.sha}}'
     - name: Update submodules
       shell: bash
       working-directory: '${{github.workspace}}'
       run: |
-        git submodule update --init --recursive
+        git submodule sync --recursive
+        git -c protocol.version=2 submodule update --init --force --depth=1 --recursive
     - name: Fetch private actions
       shell: bash
       working-directory: '${{github.workspace}}'


### PR DESCRIPTION
Inspired by this feature of actions/checkout (which I can't get to work with an ssh-key in a secret, for some reason) this uses fairly recent git features to make shallow clones work with submodules. I also combined PR and branch handling as it seems that github already provides us with a branch where the PR is merged into the latest commit of the target branch.

I've tested this with stefanzweifel/git-auto-commit-action and it's working fine for commit back into a PR with automated changes.